### PR TITLE
Clarify purpose of RSpec testing docker-compose

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,7 +63,7 @@ Terraling is a Ruby on Rails web application to let you store and browse your li
 
 * First, run the test docker-compose script:
 
-    * `$ docker-compose -f docker-compose.test.yml up`
+    * `$ docker-compose -f docker-compose.rspec.yml up`
 
 
 * Then, enter the running container via:

--- a/docker-compose.rspec.yml
+++ b/docker-compose.rspec.yml
@@ -24,4 +24,4 @@ services:
     depends_on:
       - terraling-dockerized-mysql
     entrypoint:
-      - /terraling/docker-entry.test.sh
+      - /terraling/docker-entry.rspec.sh

--- a/docker-entry.rspec.sh
+++ b/docker-entry.rspec.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-export RECAPTCHA_SITE_KEY=6LcYxasZAAAAAL25mMYFfzO-DmDEHjqkFVw0d7_5
-export RECAPTCHA_SECRET_KEY=6LcYxasZAAAAAM3ZSKVicnCsKx4U5D262UzdAUEP
-export DATABASE_CLEANER_ALLOW_PRODUCTION=true
+echo 'export DATABASE_CLEANER_ALLOW_PRODUCTION=true' >> ~/.bashrc 
 
 while true; do foo; sleep 10; done
 # RAILS_ENV=production LOCAL_DEV=true bundle exec rspec


### PR DESCRIPTION
Docker's automated build was failing because it thought that `docker-compose.test.yml` was part of Autotest. This change clarifies the purpose of that specific Docker Compose config by renaming it to `docker-compose.rspec.yml`.