### PR TITLE
Hotfix/group member fixes

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -6,8 +6,8 @@ class MembershipsController < GroupDataController
     pagination_options = {db_mode: true, db_field: "name", default_field: "a", :bootstrap3 => true, :js => false}
     @memberships, @params = current_group.memberships.
         includes(:member).to_a.
+        select { |membership| membership.member.present? }.
         alpha_paginate(params[:letter], pagination_options) do |membership|
-          # Handle nil (?!) values
           user = membership.member
           user.present? ? user.name : '*'
         end
@@ -23,8 +23,8 @@ class MembershipsController < GroupDataController
 
     @contributors, @params = current_group.memberships.
       includes(:member).with_role(:expert, :any).to_a.
+      select { |membership| membership.member.present? }.
       alpha_paginate(params[:letter], pagination_options) do |membership|
-          # Handle nil (?!) values
           user = membership.member
           user.present? ? user.name : '*'
         end

--- a/app/presenters/group_stats.rb
+++ b/app/presenters/group_stats.rb
@@ -19,7 +19,7 @@ module GroupStats
   end
 
   def members_in_group
-    @mem_total ||= self.memberships.where(group_id: id).count
+    @mem_total ||= self.memberships.where(group_id: id).select { |membership| membership.member.present? }.count
   end
 
   def lings_with_property_quota(depth)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   terraling-dockerized:
     build: .
-    image: terraling/terraling-dev
+    image: terraling/terraling
     restart: always
     volumes:
       - .:/terraling/

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -5,7 +5,7 @@ export SMTP_PASS=password
 
 export RECAPTCHA_SITE_KEY=6LcYxasZAAAAAL25mMYFfzO-DmDEHjqkFVw0d7_5
 export RECAPTCHA_SECRET_KEY=6LcYxasZAAAAAM3ZSKVicnCsKx4U5D262UzdAUEP
-export NEW_USER_NOTIFY=dev@localhost
+export NEW_USER_NOTIFY=user@example.com
 
 export RAILS_ENV=development
 export LOCAL_DEV=true


### PR DESCRIPTION
Removed memberships with nil users from counting towards the total count, and from being displayed in Members/Contributors list. We need to delete the memberships when deleting users, but this fix should do for now.