### PR TITLE
Select unique memberships only

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -24,6 +24,7 @@ class MembershipsController < GroupDataController
     @contributors, @params = current_group.memberships.
       includes(:member).with_role(:expert, :any).to_a.
       select { |membership| membership.member.present? }.
+      uniq.
       alpha_paginate(params[:letter], pagination_options) do |membership|
           user = membership.member
           user.present? ? user.name : '*'


### PR DESCRIPTION
Experts were showing up several times in the Contributor table if they were experts of multiple languages.